### PR TITLE
Add projekts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ allegro.log
 .DS_Store
 
 .project_info
+out.tmp
 

--- a/Makefile
+++ b/Makefile
@@ -21,20 +21,27 @@ NCURSES_LIB=ncurses
 
 
 SOURCES := $(shell find src -name '*.cpp')
-PROGRAMS := $(shell find programs -name '*.cpp')
+PROJEKTS := $(shell find projekts -name '*.cpp')
 OBJECTS := $(SOURCES:src/%.cpp=obj/%.o)
 TEST_SOURCES := $(shell find tests -name '*.cpp')
 TEST_OBJECTS := $(TEST_SOURCES:tests/%.cpp=obj/tests/%.o)
 INDIVIDUAL_TEST_EXECUTABLES := $(TEST_SOURCES:tests/%.cpp=bin/tests/%)
-PROGRAM_EXECUTABLES := $(PROGRAMS:programs/%.cpp=bin/%)
+PROJEKT_EXECUTABLES := $(PROJEKTS:projekts/%.cpp=bin/%)
 
 
 
-progs: $(PROGRAM_EXECUTABLES)
+projekts: $(PROJEKT_EXECUTABLES)
 
 
 
-bin/%: programs/%.cpp $(OBJECTS)
+bin/%: projekts/%.cpp $(OBJECTS)
+	@printf "compiling program \e[1m\e[36m$<\033[0m..."
+	@g++ -std=gnu++11 -Wall -Wuninitialized -Weffc++ $(OBJECTS) $< -o $@ -I./include -l$(NCURSES_LIB)
+	@echo "done. Executable at \033[1m\033[32m$@\033[0m"
+
+
+
+bin/$(PROJECT_NAME_SNAKE_CASE): programs/$(PROJECT_NAME_SNAKE_CASE).cpp $(OBJECTS)
 	@printf "compiling program \e[1m\e[36m$<\033[0m..."
 	@g++ -std=gnu++11 -Wall -Wuninitialized -Weffc++ $(OBJECTS) $< -o $@ -I./include -l$(NCURSES_LIB)
 	@echo "done. Executable at \033[1m\033[32m$@\033[0m"

--- a/include/Projekt.h
+++ b/include/Projekt.h
@@ -1,0 +1,32 @@
+#include <ncurses_art/AppController.h>
+
+#include <ncurses_art/Element/ElementBase.h>
+#include <ncurses_art/Element/HeaderBar.h>
+#include <ncurses_art/Element/Menu.h>
+#include <ncurses_art/Element/Rectangle.h>
+#include <ncurses_art/Element/Scene.h>
+#include <ncurses_art/Element/Text.h>
+#include <ncurses_art/EventTypes.h>
+
+class Projekt : public Scene
+{
+public:
+   Projekt();
+   ~Projekt();
+
+   bool process_input(char input_ch) override;
+   bool process_event(std::string event) override;
+};
+
+Projekt::~Projekt() {}
+
+int main(int, char**)
+{
+   AppController app_controller;
+   app_controller.initialize();
+   Projekt projekt;
+   projekt.set_app_controller(&app_controller);
+   app_controller.set_scene(&projekt);
+   app_controller.run_loop();
+   return 0;
+}

--- a/include/ncurses_art/Element/Menu.h
+++ b/include/ncurses_art/Element/Menu.h
@@ -16,11 +16,13 @@ public:
    Menu(float x, float y, std::vector<std::string> options = {});
    ~Menu();
 
+   bool set_cursor_pos(int pos);
    void set_styles(int styles);
    bool set_options(std::vector<std::string> options);
 
    float get_x();
    float get_y();
+   int get_cursor_pos();
    void move_cursor_up();
    void move_cursor_down();
    std::string current_selection();

--- a/include/ncurses_art/Element/Scene.h
+++ b/include/ncurses_art/Element/Scene.h
@@ -21,7 +21,7 @@ public:
    virtual bool process_input(char input_ch);
    virtual bool process_event(std::string event);
 
-   const std::vector<ElementBase *> &get_elements();
+   std::vector<ElementBase *> &get_elements();
 
    void draw() override;
 };

--- a/include/ncurses_art/Element/Text.h
+++ b/include/ncurses_art/Element/Text.h
@@ -21,5 +21,8 @@ public:
    Text &underline(bool on=true);
    Text &reverse(bool on=true);
    Text &color(int color_num);
+
+   std::string get_text();
+
    void draw() override;
 };

--- a/include/ncurses_art/EventTypes.h
+++ b/include/ncurses_art/EventTypes.h
@@ -2,4 +2,5 @@
 
 #include <string>
 
+extern const std::string EVENT_PROGRAM_INITIALIZED;
 extern const std::string EVENT_ABORT_PROGRAM;

--- a/projekts/basic_projekt.cpp
+++ b/projekts/basic_projekt.cpp
@@ -1,0 +1,75 @@
+#include <Projekt.h>
+
+#include "projekt_helper.h"
+
+#include <fstream>
+#include <streambuf>
+
+#define GIT_DIFF_COMMAND "(d) git diff"
+#define GIT_STATUS_COMMAND "(s) git status"
+#define GIT_LOG_COMMAND "(l) git log"
+#define QUIT_COMMAND "(q) quit"
+#define LOAD_FILE_COMMAND "   load_file"
+
+Projekt::Projekt()
+{
+   current_project = this;
+
+   elements.push_back(new Menu(1, 3, {
+      GIT_DIFF_COMMAND,
+      GIT_STATUS_COMMAND,
+      GIT_LOG_COMMAND,
+      QUIT_COMMAND,
+   }));
+   last_element().set_name("main_menu");
+
+   elements.push_back(new Text("[ output text empty ]", 0, 10));
+   last_element().set_name("body_text");
+}
+
+bool Projekt::process_input(char input_ch)
+{
+   switch(input_ch)
+   {
+   case 'j': emit_event(MOVE_CURSOR_DOWN); break;
+   case 'k': emit_event(MOVE_CURSOR_UP); break;
+   case 'q': emit_event(EVENT_ABORT_PROGRAM); break;
+   case 10: emit_event(CHOOSE_CURRENT_MENU_ITEM); break;
+   default: return false; break;
+   }
+
+   return true;
+}
+
+bool Projekt::process_event(std::string event)
+{
+   if (event == MOVE_CURSOR_DOWN) find_menu("main_menu").move_cursor_down();
+   else if (event == MOVE_CURSOR_UP) find_menu("main_menu").move_cursor_up();
+   else if (event == QUIT_COMMAND) emit_event(EVENT_ABORT_PROGRAM);
+   else if (event == CHOOSE_CURRENT_MENU_ITEM)
+   {
+      std::string selection = find_menu("main_menu").current_selection();
+      emit_event(find_menu("main_menu").current_selection());
+   }
+   else if (event == GIT_DIFF_COMMAND)
+   {
+      system("git diff > \"out.tmp\"");
+      emit_event(LOAD_FILE_COMMAND);
+   }
+   else if (event == GIT_STATUS_COMMAND)
+   {
+      system("git status > \"out.tmp\"");
+      emit_event(LOAD_FILE_COMMAND);
+   }
+   else if (event == GIT_LOG_COMMAND)
+   {
+      system("git log --pretty=tformat:'\''%an%x09%ad%x09%C(yellow)%h%Creset%x09%s'\'' --date=format:'\''%Y-%m-%d %H:%M:%S'\'' -12 > \"out.tmp\"");
+      emit_event(LOAD_FILE_COMMAND);
+   }
+   else if (event == LOAD_FILE_COMMAND)
+   {
+      find_text("body_text").set_text(get_file_contents());
+   }
+
+   return true;
+}

--- a/projekts/fancy_stager.cpp
+++ b/projekts/fancy_stager.cpp
@@ -1,0 +1,226 @@
+#include <Projekt.h>
+#include "projekt_helper.h"
+
+#include <ncurses.h>
+
+#define COMMAND_FLIP_STAGING "flip_staging"
+#define COMMAND_REBUILD_MENU "rebuild_menu"
+#define REFRESH_TEXT_DISPLAY "refresh_text_display"
+
+class GitStatusLineDeducer
+{
+private:
+   Menu menu;
+   int line_number;
+   const std::string CHANGES_TO_BE_COMMITED_LINE = "Changes to be committed:";
+   const std::string CHANGES_NOT_STAGED_FOR_COMMIT_LINE = "Changes not staged for commit:";
+   const std::string UNTRACKED_FILES_LINE = "Untracked files:";
+
+public:
+   GitStatusLineDeducer(Menu menu_dup) : menu(menu_dup), line_number(menu.get_cursor_pos()) {}
+
+   std::string line()
+   {
+      return menu.current_selection();
+   }
+
+   bool is_file_line()
+   {
+      return !(line().empty() || line()[0] != '\t');
+   }
+
+   bool a_proceeding_line_matches(std::string str, std::vector<std::string> nots = {})
+   {
+      int traversing_line_number = line_number;
+      bool line_matched = false;
+      while (traversing_line_number >= 0)
+      {
+         menu.set_cursor_pos(traversing_line_number);
+         traversing_line_number--;
+
+         for (auto &anot : nots) if (menu.current_selection() == anot)
+         {
+            line_matched = false;
+            break;
+         }
+         if (menu.current_selection() == str)
+         {
+            line_matched = true;
+            break;
+         }
+      }
+      menu.set_cursor_pos(line_number);
+      return line_matched;
+   }
+
+   bool line_is_staged()
+   {
+      if (!is_file_line()) return false;
+      return a_proceeding_line_matches(CHANGES_TO_BE_COMMITED_LINE, { CHANGES_NOT_STAGED_FOR_COMMIT_LINE, UNTRACKED_FILES_LINE });
+   }
+
+   bool line_is_untracked()
+   {
+      if (!is_file_line()) return false;
+      return a_proceeding_line_matches(UNTRACKED_FILES_LINE, { CHANGES_NOT_STAGED_FOR_COMMIT_LINE, CHANGES_TO_BE_COMMITED_LINE });
+   }
+
+   bool line_is_not_staged()
+   {
+      if (!is_file_line()) return false;
+      return a_proceeding_line_matches(CHANGES_NOT_STAGED_FOR_COMMIT_LINE, { CHANGES_TO_BE_COMMITED_LINE, UNTRACKED_FILES_LINE });
+   }
+
+   std::string parse_directive()
+   {
+      if (!is_file_line()) return "";
+      std::vector<std::string> tokens = split_string(line(), " ");
+      std::string possible_directive_string = tokens.front();
+      if (possible_directive_string.back() != ':') return "";
+      // erase the first and last characters
+      return possible_directive_string.substr(1, possible_directive_string.size() - 2);
+   }
+
+   std::string parse_filename()
+   {
+      if (!is_file_line()) return "";
+      std::vector<std::string> tokens = split_string(line(), " ");
+      std::string untrimmed = tokens.back();
+      return untrimmed.substr(
+            untrimmed.find_first_not_of('\t'),
+            (untrimmed.find_last_not_of('\t') - untrimmed.find_first_not_of('\t')) + 1
+         );
+   }
+};
+
+Projekt::Projekt() { current_project = this; }
+bool Projekt::process_input(char ch)
+{
+   switch(ch)
+   {
+   case 'j': emit_event(MOVE_CURSOR_DOWN); break;
+   case 'k': emit_event(MOVE_CURSOR_UP); break;
+   case 10: emit_event(COMMAND_FLIP_STAGING); break;
+   case 'q': emit_event(EVENT_ABORT_PROGRAM); break;
+   default: return false; break;
+   }
+   return true;
+}
+bool Projekt::process_event(std::string e)
+{
+   if (e == EVENT_PROGRAM_INITIALIZED)
+   {
+      init_color(20, (int)(255.0/255.0*1000), 0, (int)(175.0/255.0*1000));
+      init_color(21, (int)(175.0/255.0*1000), 0, (int)(255.0/255.0*1000));
+      init_color(22, (int)(96.0/255.0*1000), 0, (int)(128.0/255.0*1000));
+      init_color(23, (int)(175.0/255.0*1000), 0, (int)(96.0/255.0*1000));
+      init_color(24, 0, 0, 0);
+      init_pair(1, 20, COLOR_BLACK);
+      init_pair(2, COLOR_BLACK, 20);
+      init_pair(3, COLOR_BLACK, 21);
+      init_pair(4, 24, 22);
+      init_pair(5, COLOR_MAGENTA, 23);
+      create_menu("main_menu").set_styles(COLOR_PAIR(1));
+      create_text("body_text", 80, 3).set_styles(COLOR_PAIR(2));
+
+      emit_event(COMMAND_REBUILD_MENU);
+   }
+   else if (e == REFRESH_TEXT_DISPLAY)
+   {
+      Menu &menu = find_menu("main_menu");
+      GitStatusLineDeducer git_status_line_deducer(menu);
+      std::stringstream system_command;
+      Text &text = find_text("body_text");
+
+      if (git_status_line_deducer.is_file_line())
+      {
+         std::string filename = git_status_line_deducer.parse_filename();
+
+         if (git_status_line_deducer.line_is_untracked())
+         {
+            text.set_styles(COLOR_PAIR(5));
+            system_command << "cat \"" << filename << "\" > \"out.tmp\"";
+         }
+         else if (git_status_line_deducer.line_is_not_staged())
+         {
+            text.set_styles(COLOR_PAIR(4));
+            system_command << "git diff \"" << filename << "\" > \"out.tmp\"";
+         }
+         else if (git_status_line_deducer.line_is_staged())
+         {
+            text.set_styles(COLOR_PAIR(3));
+            system_command << "git diff --staged \"" << filename << "\" > \"out.tmp\"";
+         }
+      }
+      else
+      {
+         text.set_styles(COLOR_PAIR(2));
+         system_command << "git diff --staged > \"out.tmp\"";
+      }
+
+      system(system_command.str().c_str());
+
+      std::string command_output = get_file_contents();
+      text.set_text(command_output);
+   }
+   else if (e == MOVE_CURSOR_DOWN)
+   {
+      Menu &menu = find_menu("main_menu");
+      menu.move_cursor_down();
+      emit_event(REFRESH_TEXT_DISPLAY);
+   }
+   else if (e == MOVE_CURSOR_UP)
+   {
+      Menu &menu = find_menu("main_menu");
+      menu.move_cursor_up();
+      emit_event(REFRESH_TEXT_DISPLAY);
+   }
+   else if (e == COMMAND_FLIP_STAGING)
+   {
+      Menu &menu = find_menu("main_menu");
+      std::string current_selection = menu.current_selection();
+      std::vector<std::string> line_tokens = split_string(current_selection, " ");
+
+      GitStatusLineDeducer git_status_line_deducer(menu);
+
+      if (git_status_line_deducer.is_file_line())
+      {
+         if (git_status_line_deducer.line_is_not_staged() || git_status_line_deducer.line_is_untracked())
+         {
+            std::stringstream system_command;
+            system_command << "git add " << git_status_line_deducer.parse_filename();
+            system_command << " > /dev/null";
+            system(system_command.str().c_str());
+            emit_event(COMMAND_REBUILD_MENU);
+         }
+         else
+         {
+            std::stringstream system_command;
+            system_command << "git reset " << git_status_line_deducer.parse_filename();
+            system_command << " > /dev/null";
+            system(system_command.str().c_str());
+            emit_event(COMMAND_REBUILD_MENU);
+         }
+      }
+
+      //std::ofstream ofs("asdf.txt");
+      //ofs
+         //<< "staged: " << git_status_line_deducer.line_is_staged() << std::endl
+         //<< "untracked: " << git_status_line_deducer.line_is_untracked() << std::endl
+         //<< "not_staged: " << git_status_line_deducer.line_is_not_staged() << std::endl
+         //<< git_status_line_deducer.is_file_line() << std::endl
+         //<< git_status_line_deducer.is_file_line() << std::endl
+         //<< git_status_line_deducer.parse_directive() << std::endl
+         //<< git_status_line_deducer.parse_filename() << std::endl;
+      //ofs.close();
+      //throwit("COMMAND_FLIP_STAGING not supported yet");
+   }
+   else if (e == COMMAND_REBUILD_MENU)
+   {
+      system("git status > \"out.tmp\"");
+      std::string txt = get_file_contents();
+      std::vector<std::string> tokens = split_string(txt, "\n");
+      find_menu("main_menu").set_options(tokens);
+   }
+   return true;
+}

--- a/projekts/log_walker.cpp
+++ b/projekts/log_walker.cpp
@@ -12,6 +12,7 @@
 #define SET_DIFF_TEXT "set_diff_text"
 #define COPY_CURRENT_HASH_TO_CLIPBOARD "copy_current_hash_to_clipboard"
 #define COPY_INTERACTIVE_REBASE_COMMAND "copy_interactive_rebase_command"
+#define COPY_FANCY_FIXUP_COMMAND "copy_fancy_fixup_command"
 
 void set_commit_log_menu()
 {
@@ -49,6 +50,7 @@ bool Projekt::process_input(char input_ch)
    case 'q': emit_event(EVENT_ABORT_PROGRAM); break;
    case 'y': emit_event(COPY_CURRENT_HASH_TO_CLIPBOARD); break;
    case 'r': emit_event(COPY_INTERACTIVE_REBASE_COMMAND); break;
+   case 'f': emit_event(COPY_FANCY_FIXUP_COMMAND); break;
    case 10: emit_event(CHOOSE_CURRENT_MENU_ITEM); break;
    default: return false; break;
    }
@@ -84,6 +86,15 @@ bool Projekt::process_event(std::string event)
 
       std::stringstream command;
       command << "printf \"git rebase -i " << git_line_tokens[2] << "~\" | pbcopy";
+      system(command.str().c_str());
+   }
+   else if (event == COPY_FANCY_FIXUP_COMMAND)
+   {
+      std::string selection_text = find_menu("main_menu").current_selection();
+      auto git_line_tokens = split_string(selection_text, "\t");
+
+      std::stringstream command;
+      command << "printf \"git_fixup " << git_line_tokens[2] << "\" | pbcopy";
       system(command.str().c_str());
    }
    else if (event == SET_DIFF_TEXT)

--- a/projekts/log_walker.cpp
+++ b/projekts/log_walker.cpp
@@ -1,0 +1,96 @@
+#include <Projekt.h>
+
+#include <iostream>
+
+#include <cstdlib>
+
+#include <ncurses.h>
+
+#include "projekt_helper.h"
+
+#define SET_COMMIT_LOG_MENU "set_commit_log_menu"
+#define SET_DIFF_TEXT "set_diff_text"
+#define COPY_CURRENT_HASH_TO_CLIPBOARD "copy_current_hash_to_clipboard"
+
+void set_commit_log_menu()
+{
+   system("git log --pretty=tformat:'\''%an%x09%ad%x09%C(yellow)%h%Creset%x09%s'\'' --date=format:'\''%Y-%m-%d %H:%M:%S'\'' -100 > \"out.tmp\"");
+   std::string txt = get_file_contents();
+   std::vector<std::string> tokens = split_string(txt, "\n");
+   find_text("body_text").set_text(tokens[0]);
+   find_menu("main_menu").set_options(tokens);
+}
+
+Projekt::Projekt()
+{
+   current_project = this;
+
+   init_color(20, 0, (int)(255.0/255.0*1000), (int)(175.0/255.0*1000));
+
+   init_pair(1, COLOR_BLACK, 20);
+
+   elements.push_back(new Text("[ output text empty ]", 0, 5));
+   last_element().set_name("body_text");
+
+   elements.push_back(new Menu(100, 5, { "[ menu empty ]" }));
+   last_menu().set_styles(COLOR_PAIR(1));
+   last_element().set_name("main_menu");
+
+   set_commit_log_menu();
+}
+
+bool Projekt::process_input(char input_ch)
+{
+   switch(input_ch)
+   {
+   case 'j': emit_event(MOVE_CURSOR_DOWN); break;
+   case 'k': emit_event(MOVE_CURSOR_UP); break;
+   case 'q': emit_event(EVENT_ABORT_PROGRAM); break;
+   case 'y': emit_event(COPY_CURRENT_HASH_TO_CLIPBOARD); break;
+   case 10: emit_event(CHOOSE_CURRENT_MENU_ITEM); break;
+   default: return false; break;
+   }
+
+   return true;
+}
+
+bool Projekt::process_event(std::string event)
+{
+   if (event == MOVE_CURSOR_DOWN)
+   {
+      find_menu("main_menu").move_cursor_down();
+      emit_event(SET_DIFF_TEXT);
+   }
+   else if (event == MOVE_CURSOR_UP)
+   {
+      find_menu("main_menu").move_cursor_up();
+      emit_event(SET_DIFF_TEXT);
+   }
+   else if (event == COPY_CURRENT_HASH_TO_CLIPBOARD)
+   {
+      std::string selection_text = find_menu("main_menu").current_selection();
+      auto git_line_tokens = split_string(selection_text, "\t");
+
+      std::stringstream command;
+      command << "echo " << git_line_tokens[2] << " | pbcopy";
+      system(command.str().c_str());
+   }
+   else if (event == SET_DIFF_TEXT)
+   {
+      std::string selection_text = find_menu("main_menu").current_selection();
+      auto git_line_tokens = split_string(selection_text, "\t");
+
+      std::stringstream command;
+      command << "git show " << git_line_tokens[2] << " > \"out.tmp\"";
+      system(command.str().c_str());
+
+      std::string command_output = get_file_contents();
+      find_text("body_text").set_text(command_output);
+   }
+   else if (event == SET_COMMIT_LOG_MENU)
+   {
+      set_commit_log_menu();
+   }
+
+   return true;
+}

--- a/projekts/log_walker.cpp
+++ b/projekts/log_walker.cpp
@@ -11,6 +11,7 @@
 #define SET_COMMIT_LOG_MENU "set_commit_log_menu"
 #define SET_DIFF_TEXT "set_diff_text"
 #define COPY_CURRENT_HASH_TO_CLIPBOARD "copy_current_hash_to_clipboard"
+#define COPY_INTERACTIVE_REBASE_COMMAND "copy_interactive_rebase_command"
 
 void set_commit_log_menu()
 {
@@ -47,6 +48,7 @@ bool Projekt::process_input(char input_ch)
    case 'k': emit_event(MOVE_CURSOR_UP); break;
    case 'q': emit_event(EVENT_ABORT_PROGRAM); break;
    case 'y': emit_event(COPY_CURRENT_HASH_TO_CLIPBOARD); break;
+   case 'r': emit_event(COPY_INTERACTIVE_REBASE_COMMAND); break;
    case 10: emit_event(CHOOSE_CURRENT_MENU_ITEM); break;
    default: return false; break;
    }
@@ -73,6 +75,15 @@ bool Projekt::process_event(std::string event)
 
       std::stringstream command;
       command << "printf \"" << git_line_tokens[2] << "\" | pbcopy";
+      system(command.str().c_str());
+   }
+   else if (event == COPY_INTERACTIVE_REBASE_COMMAND)
+   {
+      std::string selection_text = find_menu("main_menu").current_selection();
+      auto git_line_tokens = split_string(selection_text, "\t");
+
+      std::stringstream command;
+      command << "printf \"git rebase -i " << git_line_tokens[2] << "~\" | pbcopy";
       system(command.str().c_str());
    }
    else if (event == SET_DIFF_TEXT)

--- a/projekts/log_walker.cpp
+++ b/projekts/log_walker.cpp
@@ -72,7 +72,7 @@ bool Projekt::process_event(std::string event)
       auto git_line_tokens = split_string(selection_text, "\t");
 
       std::stringstream command;
-      command << "echo " << git_line_tokens[2] << " | pbcopy";
+      command << "printf \"" << git_line_tokens[2] << "\" | pbcopy";
       system(command.str().c_str());
    }
    else if (event == SET_DIFF_TEXT)

--- a/projekts/projekt_helper.h
+++ b/projekts/projekt_helper.h
@@ -1,0 +1,93 @@
+
+#include <sstream>
+
+Projekt *current_project = nullptr;
+
+std::vector<Menu *> menus()
+{
+   if (!current_project) throw std::runtime_error("Cannot retrieve menus on a nullptr current_project");
+   std::vector<Menu *> results;
+   for (ElementBase *element : current_project->get_elements())
+      if (element->is_type("Menu")) results.push_back(static_cast<Menu *>(element));
+   return results;
+}
+
+std::vector<Text *> texts()
+{
+   if (!current_project) throw std::runtime_error("Cannot retrieve tests on a nullptr current_project");
+   std::vector<Text *> results;
+   for (ElementBase *element : current_project->get_elements())
+      if (element->is_type("Text")) results.push_back(static_cast<Text *>(element));
+   return results;
+}
+
+Menu &find_menu(std::string name)
+{
+   std::vector<Menu *> results;
+   for (Menu *menu : menus()) if (menu->is_name(name)) return *menu;
+
+   std::stringstream error_message;
+   error_message << "Cannot find menu with the name \"" << name << "\"";
+   throw std::runtime_error(error_message.str());
+}
+
+Text &find_text(std::string name)
+{
+   std::vector<Text *> results;
+   for (Text *text : texts()) if (text->is_name(name)) return *text;
+
+   std::stringstream error_message;
+   error_message << "Cannot find text with the name \"" << name << "\"";
+   throw std::runtime_error(error_message.str());
+}
+
+Menu &last_menu()
+{
+   return (*menus().back());
+}
+
+ElementBase &last_element()
+{
+   if (!current_project) throw std::runtime_error("Cannot last_element on a nullptr current_project");
+   if (current_project->get_elements().empty()) throw std::runtime_error("Cannot retrieve last_element on an empty set of elements");
+   return *current_project->get_elements().back();
+}
+
+const std::string MOVE_CURSOR_DOWN = "move_cursor_down";
+const std::string MOVE_CURSOR_UP = "move_cursor_up";
+const std::string CHOOSE_CURRENT_MENU_ITEM = "choose_current_menu_item";
+
+void throwit(std::string message)
+{
+   throw std::runtime_error(message);
+}
+
+
+// file content reader
+
+#include <fstream>
+#include <streambuf>
+
+std::string get_file_contents()
+{
+   std::ifstream t("out.tmp");
+   std::string str((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
+   return str;
+}
+
+// string tokenizer
+
+std::vector<std::string> split_string(std::string s, std::string delimiter)
+{
+   std::vector<std::string> results;
+
+   size_t pos = 0;
+   std::string token;
+   while ((pos = s.find(delimiter)) != std::string::npos) {
+       token = s.substr(0, pos);
+       results.push_back(token);
+       s.erase(0, pos + delimiter.length());
+   }
+
+   return results;
+}

--- a/projekts/projekt_helper.h
+++ b/projekts/projekt_helper.h
@@ -53,6 +53,24 @@ ElementBase &last_element()
    return *current_project->get_elements().back();
 }
 
+Text &create_text(std::string name="", int x=0, int y=0)
+{
+   if (!current_project) throw std::runtime_error("Cannot create a text, current_project is not set");
+   Text *text = new Text("", x, y);
+   current_project->get_elements().push_back(text);
+   last_element().set_name(name);
+   return (*text);
+}
+
+Menu &create_menu(std::string name="")
+{
+   if (!current_project) throw std::runtime_error("Cannot create a menu, current_project is not set");
+   Menu *menu = new Menu(0, 0, {});
+   current_project->get_elements().push_back(menu);
+   last_element().set_name(name);
+   return (*menu);
+}
+
 const std::string MOVE_CURSOR_DOWN = "move_cursor_down";
 const std::string MOVE_CURSOR_UP = "move_cursor_up";
 const std::string CHOOSE_CURRENT_MENU_ITEM = "choose_current_menu_item";
@@ -92,3 +110,14 @@ std::vector<std::string> split_string(std::string s, std::string delimiter)
 
    return results;
 }
+
+// append new line to text
+
+bool append_text(Text &text, std::string str_to_append)
+{
+   std::string str = text.get_text();
+   str += str_to_append;
+   text.set_text(str);
+   return true;
+}
+

--- a/projekts/projekt_helper.h
+++ b/projekts/projekt_helper.h
@@ -88,6 +88,7 @@ std::vector<std::string> split_string(std::string s, std::string delimiter)
        results.push_back(token);
        s.erase(0, pos + delimiter.length());
    }
+   results.push_back(s);
 
    return results;
 }

--- a/projekts/projekt_helper_test.cpp
+++ b/projekts/projekt_helper_test.cpp
@@ -1,0 +1,120 @@
+#include <Projekt.h>
+#include "projekt_helper.h"
+
+#include <ncurses.h>
+
+#define TEST_APPEND_TEXT "test_append_text"
+#define TEST_SPLIT_STRING "test_split_string"
+#define MESSAGE_STARTING_TEST "message_starting_test"
+#define MESSAGE_FINISHED_TEST "message_finished_test"
+#define MESSAGE_FAILED_TEST "message_failed_test"
+
+Text *output_text = nullptr;
+
+std::string vector_to_string(std::vector<std::string> vec)
+{
+   std::ostringstream oss;
+   oss << "[ \"";
+   std::copy(vec.begin(), vec.end()-1,
+         std::ostream_iterator<std::string>(oss, "\", \""));
+   oss << vec.back() << "\" ]";
+   return oss.str();
+}
+
+std::string compose_failed_assertion(std::string test_name, std::string expected, std::string actual)
+{
+   std::stringstream ss;
+   ss << "Test \"" << test_name << "\" failed." << std::endl;
+   ss << " - Expected: " << expected << std::endl;
+   ss << " -   Actual: " << actual << std::endl;
+   return ss.str();
+}
+
+std::string compose_failed_assertion(std::string test_name, std::vector<std::string> expected, std::vector<std::string> actual)
+{
+   std::stringstream ss;
+   ss << "Test \"" << test_name << "\" failed." << std::endl;
+   ss << " - Expected: " << vector_to_string(expected) << std::endl;
+   ss << " -   Actual: " << vector_to_string(actual) << std::endl;
+   return ss.str();
+}
+
+bool assert(Projekt *projekt, std::string name, std::vector<std::string> expected, std::vector<std::string> actual)
+{
+   if (expected != actual)
+   {
+      append_text(find_text("output_text"), compose_failed_assertion(name, expected, actual));
+      projekt->emit_event(MESSAGE_FAILED_TEST);
+   }
+   return true;
+}
+
+bool assert(Projekt *projekt, std::string name, std::string expected, std::string actual)
+{
+   if (expected != actual)
+   {
+      append_text(find_text("output_text"), compose_failed_assertion(name, expected, actual));
+      projekt->emit_event(MESSAGE_FAILED_TEST);
+   }
+   return true;
+}
+
+Projekt::Projekt() { current_project = this; }
+bool Projekt::process_input(char ch)
+{
+   switch(ch)
+   {
+   case 'q': emit_event(EVENT_ABORT_PROGRAM); break;
+   }
+   return true;
+}
+bool Projekt::process_event(std::string e)
+{
+   if (e == EVENT_PROGRAM_INITIALIZED)
+   {
+      init_color(20, 0, (int)(255.0/255.0*1000), (int)(96.0/255.0*1000));
+      init_pair(1, 20, COLOR_BLACK);
+      output_text = &create_text("output_text", 0, 5);
+
+      emit_event(TEST_APPEND_TEXT);
+      emit_event(TEST_SPLIT_STRING);
+   }
+   else if (e == MESSAGE_STARTING_TEST)
+   {
+      append_text(find_text("output_text"), "\n-- Test starting");
+   }
+   else if (e == MESSAGE_FINISHED_TEST)
+   {
+      append_text(find_text("output_text"), "\n   -- Test finished");
+   }
+   else if (e == MESSAGE_FAILED_TEST)
+   {
+      append_text(find_text("output_text"), "\n   !! FAILED");
+   }
+   else if (e == TEST_APPEND_TEXT)
+   {
+      emit_event(MESSAGE_STARTING_TEST);
+      std::string initial_text = "initial text";
+      Text text(initial_text, 0, 0);
+      std::string appending_text = "foo";
+      append_text(text, appending_text);
+      std::string expected_text = "initial textfoo";
+      std::string returned_text = text.get_text();
+
+      assert(this, TEST_APPEND_TEXT, expected_text, returned_text);
+
+      emit_event(MESSAGE_FINISHED_TEST);
+   }
+   else if (e == TEST_SPLIT_STRING)
+   {
+      emit_event(MESSAGE_STARTING_TEST);
+      std::string str = "This is a string";
+      std::vector<std::string> actual = split_string(str, " ");
+      std::vector<std::string> expected = {"This", "is", "a", "string"};
+
+      assert(this, TEST_SPLIT_STRING, expected, actual);
+
+      emit_event(MESSAGE_FINISHED_TEST);
+   }
+   return true;
+}

--- a/src/AppController.cpp
+++ b/src/AppController.cpp
@@ -36,6 +36,7 @@ void AppController::initialize()
    screen.initialize();
    initialized = true;
    nodelay(stdscr, true);
+   emit_event(EVENT_PROGRAM_INITIALIZED);
 }
 
 void AppController::set_scene(Scene *scene)

--- a/src/Element/Menu.cpp
+++ b/src/Element/Menu.cpp
@@ -18,6 +18,14 @@ Menu::~Menu()
 {
 }
 
+bool Menu::set_cursor_pos(int pos)
+{
+   if (pos < 0) throw std::runtime_error("Cannot set_cursor_pos to a negative number");
+   if (options.empty()) cursor_pos = 0;
+   else cursor_pos = pos % options.size();
+   return true;
+}
+
 void Menu::set_styles(int styles)
 {
    this->styles = styles;
@@ -38,6 +46,11 @@ float Menu::get_x()
 float Menu::get_y()
 {
    return y;
+}
+
+int Menu::get_cursor_pos()
+{
+   return cursor_pos;
 }
 
 void Menu::move_cursor_up()

--- a/src/Element/Scene.cpp
+++ b/src/Element/Scene.cpp
@@ -35,7 +35,7 @@ bool Scene::process_event(std::string event)
    return true;
 }
 
-const std::vector<ElementBase *> &Scene::get_elements()
+std::vector<ElementBase *> &Scene::get_elements()
 {
    return elements;
 }

--- a/src/Element/Text.cpp
+++ b/src/Element/Text.cpp
@@ -62,11 +62,35 @@ std::string Text::get_text()
    return text;
 }
 
+#include <vector>
+std::vector<std::string> ___split_string(std::string s, std::string delimiter);
+
 void Text::draw()
 {
    float str_width = text.length();
    float x_pos = x - (str_width * align_x);
    attron(styles);
-   mvaddstr((int)y, (int)x_pos, text.c_str());
+   int yy = 0;
+   for (auto &line : ___split_string(text, "\n"))
+      mvaddstr((int)y + yy++, (int)x_pos, line.c_str());
    attroff(styles);
+}
+
+////
+
+
+std::vector<std::string> ___split_string(std::string s, std::string delimiter)
+{
+   std::vector<std::string> results;
+
+   size_t pos = 0;
+   std::string token;
+   while ((pos = s.find(delimiter)) != std::string::npos) {
+       token = s.substr(0, pos);
+       results.push_back(token);
+       s.erase(0, pos + delimiter.length());
+   }
+   results.push_back(s);
+
+   return results;
 }

--- a/src/Element/Text.cpp
+++ b/src/Element/Text.cpp
@@ -57,6 +57,11 @@ Text &Text::color(int color_num)
    return *this;
 }
 
+std::string Text::get_text()
+{
+   return text;
+}
+
 void Text::draw()
 {
    float str_width = text.length();

--- a/src/EventTypes.cpp
+++ b/src/EventTypes.cpp
@@ -1,3 +1,4 @@
 #include <ncurses_art/EventTypes.h>
 
 const std::string EVENT_ABORT_PROGRAM = "abort_program";
+const std::string EVENT_PROGRAM_INITIALIZED = "program_initialized";

--- a/tests/Element/MenuTest.cpp
+++ b/tests/Element/MenuTest.cpp
@@ -83,3 +83,36 @@ TEST(MenuTest, can_get_the_y_position)
    Menu menu3(0, -10, {});
    ASSERT_EQ(-10, menu3.get_y());
 }
+
+TEST(MenuTest, can_get_an_set_the_cursor_position)
+{
+   Menu menu(0, 0, { "Option1", "Option2", "Option3" });
+
+   ASSERT_EQ(0, menu.get_cursor_pos());
+
+   ASSERT_TRUE(menu.set_cursor_pos(2));
+   ASSERT_EQ(2, menu.get_cursor_pos());
+
+   ASSERT_TRUE(menu.set_cursor_pos(1));
+   ASSERT_EQ(1, menu.get_cursor_pos());
+}
+
+TEST(MenuTest, when_setting_the_cursor_pos_to_a_negative_number_throws_an_exception)
+{
+   Menu menu(0, 0, { "Option1", "Option2", "Option3" });
+
+   ASSERT_THROW(menu.set_cursor_pos(-1), std::runtime_error);
+}
+
+TEST(MenuTest, when_setting_the_cursor_pos_will_modulo_the_position_if_gt_number_of_options)
+{
+   Menu menu(0, 0, { "Option1", "Option2", "Option3" });
+
+   ASSERT_EQ(0, menu.get_cursor_pos());
+
+   ASSERT_TRUE(menu.set_cursor_pos(3));
+   ASSERT_EQ(0, menu.get_cursor_pos());
+
+   ASSERT_TRUE(menu.set_cursor_pos(7));
+   ASSERT_EQ(1, menu.get_cursor_pos());
+}

--- a/tests/Element/TextTest.cpp
+++ b/tests/Element/TextTest.cpp
@@ -12,3 +12,13 @@ TEST (TextTest, has_the_expected_type)
    Text text("Hello World", 10.0f, 10.0f);
    EXPECT_EQ("Text", text.get_type());
 }
+
+TEST (TextTest, can_get_an_set_text)
+{
+   Text text("Hello World", 0, 0);
+   EXPECT_EQ("Hello World", text.get_text());
+   ASSERT_TRUE(text.set_text("How is your day?"));
+   ASSERT_EQ("How is your day?", text.get_text());
+   ASSERT_TRUE(text.set_text("Good, I hope :)"));
+   ASSERT_EQ("Good, I hope :)", text.get_text());
+}

--- a/tests/EventTypesTest.cpp
+++ b/tests/EventTypesTest.cpp
@@ -5,4 +5,5 @@
 TEST(EventTypesTest, constants_contain_the_expected_values)
 {
    ASSERT_EQ("abort_program", EVENT_ABORT_PROGRAM);
+   ASSERT_EQ("program_initialized", EVENT_PROGRAM_INITIALIZED);
 }


### PR DESCRIPTION
Yo this is art

Adds some sick projekts "fancy_stager" and "log_walker", even a test suite projekt:

## Fancy Status

Visually interactive wrap of "git status" where you can add/remove files menu style:

<img width="1440" alt="2 fancy_stager 2017-12-30 04-52-55" src="https://user-images.githubusercontent.com/772949/34453559-f4512a98-ed25-11e7-829d-c472981ca6c8.png">

## Log Walker

Interactively walk through "git log", copy hashes and souped up rebase commands to the clipboard.

<img width="1440" alt="2 log_walker 2017-12-30 05-31-52" src="https://user-images.githubusercontent.com/772949/34453598-3f17cf14-ed26-11e7-8b4e-7e132de11fc6.png">

## projekt_test_helper

Simple test suite, help with projekt development:

<img width="1440" alt="2 projekt_helper_t 2017-12-30 02-03-07" src="https://user-images.githubusercontent.com/772949/34453602-653ffbbc-ed26-11e7-9821-51be18fec1cd.png">
